### PR TITLE
Tag a new version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.0.32',
+    version='0.0.32+extensions1',
 
     description='Run bazel in Docker, in a reproducible and portable container.',
     long_description=long_description,


### PR DESCRIPTION
This allow clients to detect that an "extensions-enabled"
dazel is already installed.